### PR TITLE
Run kubectl commands remotely

### DIFF
--- a/docs/examples/dnd/cluster.tf
+++ b/docs/examples/dnd/cluster.tf
@@ -67,7 +67,6 @@ resource "docker_container" "haproxy" {
   image                 = "haproxy"
   hostname              = "${var.name_prefix}haproxy"
   start                 = true
-  rm                    = true
   privileged            = true
   must_run              = true
   restart               = "no"
@@ -168,7 +167,6 @@ resource "docker_container" "master" {
   image                 = "${var.img}"
   hostname              = "${var.name_prefix}master-${count.index}"
   start                 = true
-  rm                    = true
   privileged            = true
   must_run              = true
   restart               = "no"
@@ -237,7 +235,6 @@ resource "docker_container" "worker" {
   image                 = "${var.img}"
   hostname              = "${var.name_prefix}worker-${count.index}"
   start                 = true
-  rm                    = true
   privileged            = true
   must_run              = true
   restart               = "no"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-cmd/cmd v1.0.4
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/gookit/color v1.1.7
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/gookit/color v1.1.7 h1:WR5I/mhSHzemW2DzG54hTsUb7OzaREvkcmUG4/WST4Q=
+github.com/gookit/color v1.1.7/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20190208042652-bc37892e1968/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=

--- a/internal/ssh/base_test.go
+++ b/internal/ssh/base_test.go
@@ -1,0 +1,90 @@
+// Copyright © 2019 Alvaro Saurin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/communicator/remote"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+type DummyOutput struct{}
+
+func (_ DummyOutput) Output(s string) {
+	fmt.Print(s)
+}
+
+type DummyCommunicator struct{}
+
+func (_ DummyCommunicator) Connect(terraform.UIOutput) error {
+	return nil
+}
+
+func (_ DummyCommunicator) Disconnect() error {
+	return nil
+}
+
+func (_ DummyCommunicator) Timeout() time.Duration {
+	return 1 * time.Hour
+}
+
+func (_ DummyCommunicator) ScriptPath() string {
+	return ""
+}
+
+func (_ DummyCommunicator) Start(*remote.Cmd) error {
+	return nil
+}
+
+func (_ DummyCommunicator) Upload(string, io.Reader) error {
+	return nil
+}
+
+func (_ DummyCommunicator) UploadScript(string, io.Reader) error {
+	return nil
+}
+
+func (_ DummyCommunicator) UploadDir(string, string) error {
+	return nil
+}
+
+func TestApply(t *testing.T) {
+	counter := 0
+	appliers := []Applyer{
+		DoMessage("test"),
+		ApplyFunc(func(o terraform.UIOutput, comm communicator.Communicator, useSudo bool) error {
+			counter = counter + 1
+			return nil
+		}),
+		ApplyError("some error"),
+	}
+
+	o := DummyOutput{}
+	comm := DummyCommunicator{}
+
+	err := Apply(appliers, o, comm, false)
+	if err == nil {
+		t.Fatal("Error: no error detected")
+	}
+	if counter > 0 {
+		t.Fatal("Error: error was raised after some function was run")
+	}
+
+}

--- a/internal/ssh/dirs.go
+++ b/internal/ssh/dirs.go
@@ -23,10 +23,10 @@ import (
 )
 
 // DoMkdir creates a remote directory
-func DoMkdir(path string) ApplyFunc {
+func DoMkdir(path string) Applyer {
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", path)
 	return DoComposed(
-		DoMessage(fmt.Sprintf("Creating directory %s", path)),
+		DoMessageDebug(fmt.Sprintf("Making sure directory %q exists", path)),
 		DoExec(mkdirCmd),
 	)
 }

--- a/internal/ssh/files_test.go
+++ b/internal/ssh/files_test.go
@@ -1,0 +1,54 @@
+// Copyright © 2019 Alvaro Saurin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ssh
+
+import (
+	"testing"
+)
+
+func TestTempFilenames(t *testing.T) {
+	name1, err := GetTempFilename()
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+	name2, err := GetTempFilename()
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+	names := []struct {
+		name string
+		res  bool
+	}{
+		{
+			name: name1,
+			res:  true,
+		},
+		{
+			name: name2,
+			res:  true,
+		},
+		{
+			name: "/tmp/something.tmp",
+			res:  false,
+		},
+	}
+
+	for _, testCase := range names {
+		isTemp := IsTempFilename(testCase.name)
+		if isTemp != testCase.res {
+			t.Fatalf("Error: %q detected as temp=%t when we expected temp=%t", testCase.name, isTemp, testCase.res)
+		}
+	}
+}

--- a/internal/ssh/processes.go
+++ b/internal/ssh/processes.go
@@ -28,12 +28,12 @@ func CheckProcessRunning(process string) CheckerFunc {
 }
 
 // DoRestartService restart a systemctl service
-func DoRestartService(service string) ApplyFunc {
+func DoRestartService(service string) Applyer {
 	return DoExec(fmt.Sprintf("systemctl --no-pager restart '%s'", service))
 }
 
 // DoEnableService enables a systemctl service
-func DoEnableService(service string) ApplyFunc {
+func DoEnableService(service string) Applyer {
 	log.Printf("[DEBUG] Enabling service '%s'", service)
 	return DoExec(fmt.Sprintf("systemctl --no-pager enable '%s'", service))
 }

--- a/pkg/common/certs.go
+++ b/pkg/common/certs.go
@@ -128,6 +128,9 @@ func (c *CertsConfig) FromResourceDataCerts(d *schema.ResourceData) error {
 // ToDisk dumps the certificates to disk
 func (c *CertsConfig) ToDisk(certsDir string) error {
 	writeCertOrKey := func(baseName string, certOrKeyData []byte) error {
+		if len(certOrKeyData) == 0 {
+			return nil
+		}
 		certOrKeyPath := path.Join(certsDir, baseName)
 		if _, err := keyutil.ParsePublicKeysPEM(certOrKeyData); err == nil {
 			return keyutil.WriteKey(certOrKeyPath, certOrKeyData)

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -25,8 +25,6 @@ const (
 
 	DefRuntimeEngine = "docker"
 
-	DefAdminKubeconfig = "/etc/kubernetes/admin.conf"
-
 	DefKubeadmInitConfPath = "/etc/kubernetes/kubeadm-init.conf"
 
 	DefKubeadmJoinConfPath = "/etc/kubernetes/kubeadm-join.conf"

--- a/pkg/provisioner/action_drain.go
+++ b/pkg/provisioner/action_drain.go
@@ -22,7 +22,7 @@ import (
 )
 
 // doDrainNode drains a node
-func doDrainNode(d *schema.ResourceData) ssh.ApplyFunc {
+func doDrainNode(d *schema.ResourceData) ssh.Applyer {
 	var node *v1.Node
 
 	// TODO: get the Node.Name from the IP

--- a/pkg/provisioner/action_init_addons.go
+++ b/pkg/provisioner/action_init_addons.go
@@ -24,7 +24,7 @@ import (
 )
 
 // doLoadHelm loads Helm (if enabled)
-func doLoadHelm(d *schema.ResourceData) ssh.ApplyFunc {
+func doLoadHelm(d *schema.ResourceData) ssh.Applyer {
 	opt, ok := d.GetOk("config.helm_enabled")
 	if !ok {
 		return ssh.DoMessage("Helm will not be loaded")
@@ -39,11 +39,11 @@ func doLoadHelm(d *schema.ResourceData) ssh.ApplyFunc {
 	if common.DefHelmManifest == "" {
 		return ssh.DoMessage("no manifest for Helm: Helm will not be loaded")
 	}
-	return doLocalKubectlApply(d, []string{common.DefHelmManifest})
+	return doRemoteKubectlApply(d, []string{common.DefHelmManifest})
 }
 
 // doLoadDashboard loads the dashboard (if enabled)
-func doLoadDashboard(d *schema.ResourceData) ssh.ApplyFunc {
+func doLoadDashboard(d *schema.ResourceData) ssh.Applyer {
 	opt, ok := d.GetOk("config.dashboard_enabled")
 	if !ok {
 		return ssh.DoMessage("the Dashboard will not be loaded")
@@ -58,11 +58,11 @@ func doLoadDashboard(d *schema.ResourceData) ssh.ApplyFunc {
 	if common.DefDashboardManifest == "" {
 		return ssh.DoMessage("no manifest for Dashboard: the Dashboard will not be loaded")
 	}
-	return doLocalKubectlApply(d, []string{common.DefDashboardManifest})
+	return doRemoteKubectlApply(d, []string{common.DefDashboardManifest})
 }
 
 // doLoadManifests loads some extra manifests
-func doLoadManifests(d *schema.ResourceData) ssh.ApplyFunc {
+func doLoadManifests(d *schema.ResourceData) ssh.Applyer {
 	manifestsOpt, ok := d.GetOk("manifests")
 	if !ok {
 		return ssh.DoNothing()
@@ -71,5 +71,5 @@ func doLoadManifests(d *schema.ResourceData) ssh.ApplyFunc {
 	for _, v := range manifestsOpt.([]interface{}) {
 		manifests = append(manifests, v.(string))
 	}
-	return doLocalKubectlApply(d, manifests)
+	return doRemoteKubectlApply(d, manifests)
 }

--- a/pkg/provisioner/action_init_cni.go
+++ b/pkg/provisioner/action_init_cni.go
@@ -25,7 +25,7 @@ import (
 )
 
 // doLoadCNI loads the CNI driver
-func doLoadCNI(d *schema.ResourceData) ssh.ApplyFunc {
+func doLoadCNI(d *schema.ResourceData) ssh.Applyer {
 	manifest := ""
 	if cniPluginManifestOpt, ok := d.GetOk("config.cni_plugin_manifest"); ok {
 		cniPluginManifest := strings.TrimSpace(cniPluginManifestOpt.(string))
@@ -50,5 +50,5 @@ func doLoadCNI(d *schema.ResourceData) ssh.ApplyFunc {
 	if len(manifest) == 0 {
 		return ssh.DoMessage("no CNI driver is going to be loaded")
 	}
-	return doLocalKubectlApply(d, []string{manifest})
+	return doRemoteKubectlApply(d, []string{manifest})
 }

--- a/pkg/provisioner/action_init_cri.go
+++ b/pkg/provisioner/action_init_cri.go
@@ -23,7 +23,7 @@ import (
 )
 
 // doPrepareCRI preparse the CRI in the target node
-func doPrepareCRI() ssh.ApplyFunc {
+func doPrepareCRI() ssh.Applyer {
 	return ssh.DoComposed(
 		ssh.DoUploadReaderToFile(strings.NewReader(assets.CNIDefConfCode), common.DefCniLookbackConfPath),
 		// we must reload the containers runtime engine after changing the CNI configuration

--- a/pkg/provisioner/etcd.go
+++ b/pkg/provisioner/etcd.go
@@ -208,12 +208,12 @@ func getMemberList(o terraform.UIOutput, comm communicator.Communicator, useSudo
 }
 
 // doPrintEtcdMembers prints the list of etcd members in the etcd cluster
-func doPrintEtcdMembers(d *schema.ResourceData) ssh.ApplyFunc {
+func doPrintEtcdMembers(d *schema.ResourceData) ssh.Applyer {
 	return ssh.ApplyFunc(func(o terraform.UIOutput, comm communicator.Communicator, useSudo bool) error {
 		members, err := getMemberList(o, comm, useSudo)
 		if err != nil {
 			if err == ErrNoEtcdContainer {
-				o.Output("info: etcd is not running in this node")
+				o.Output("etcd is not running in this node")
 			} else {
 				return nil
 			}
@@ -223,14 +223,14 @@ func doPrintEtcdMembers(d *schema.ResourceData) ssh.ApplyFunc {
 			return nil
 		}
 		for _, member := range members {
-			o.Output(fmt.Sprintf("info: etcd member '%s' at '%s'", member.ID, member.ClienAddrs))
+			o.Output(fmt.Sprintf("etcd member '%s' at '%s'", member.ID, member.ClienAddrs))
 		}
 		return nil
 	})
 }
 
 // doRemoveIfMember removes this node from the etcd cluster iff it was a member
-func doRemoveIfMember(d *schema.ResourceData) ssh.ApplyFunc {
+func doRemoveIfMember(d *schema.ResourceData) ssh.Applyer {
 	return ssh.ApplyFunc(func(o terraform.UIOutput, comm communicator.Communicator, useSudo bool) error {
 		// TODO: check if there is a etcd container running in this machine
 		// TODO: get the list of endpoints


### PR DESCRIPTION
* Do all the kubectl commands in the remote machine, so we can be sure we do not need direct access to the API server for provisioning the machine.
* Improved error handling by using an ApplyError()
* Some tests.

Closes #3 
