### PR TITLE
Install cloud-provider-config secret into the kube-system namespace

### DIFF
--- a/internal/assets/cloud_provider_manifest.go
+++ b/internal/assets/cloud_provider_manifest.go
@@ -9,6 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloud-provider-config
+  namespace: kube-system
 type: Opaque
 data:
   # "cloud_config" contains the Base64 encoded configuration file


### PR DESCRIPTION
Was trying out the provider when I ran into an issue with the cloud config.

Looks like the namespace is missing in the yaml, so it's showing up in the default namespace instead of kube-system.

Thanks!