### PR TITLE
Dns upstream

### DIFF
--- a/docs/Resource_kubeadm.md
+++ b/docs/Resource_kubeadm.md
@@ -15,7 +15,10 @@ resource "kubeadm" "main" {
   }
   
   network {
-    dns_domain = "my_cluster.local"  
+    dns {
+      domain = "my_cluster.local"
+    }
+  
     services = "10.25.0.0/16"
   }
 }
@@ -311,15 +314,21 @@ Example:
 ```hcl
 resource "kubeadm" "main" {
   network {
-    dns_domain = "mycluster.com"
     services   = "10.25.0.0/16"
+
+    dns {
+      domain   = "mycluster.com"
+      upstream = ["8.8.8.8", "8.8.4.4"]
+    }
   }
 }
 ```
 
 * `services` - (Optional) subnet used by k8s services. Defaults to `10.96.0.0/12`.
 * `pods` - (Optional) subnet used by pods.
-* `dns_domain` - (Optional) DNS domain used by k8s services. Defaults to `cluster.local`.
+* `dns` - (Optional) DNS options.
+  * `domain` - (Optional) DNS domain used by k8s services. Defaults to `cluster.local`.
+  * `upstream` - (Optional) list of upstream servers. Defaults to using the DNS configuration present in the node.
 
 ### `runtime`
 

--- a/docs/examples/aws/cluster.tf
+++ b/docs/examples/aws/cluster.tf
@@ -408,7 +408,9 @@ resource "kubeadm" "main" {
   }
 
   network {
-    dns_domain = "k8s.local"
+    dns {
+      domain = "k8s.local"
+    }
     services   = "10.25.0.0/16"
   }
 

--- a/docs/examples/dnd/cluster.tf
+++ b/docs/examples/dnd/cluster.tf
@@ -182,7 +182,11 @@ resource "kubeadm" "main" {
   config_path = "${var.kubeconfig}"
 
   network {
-    dns_domain = "${var.domain_name}.k8s.local"
+    dns {
+      domain   = "${var.domain_name}.k8s.local"
+      upstream = ["8.8.8.8", "8.8.4.4"]
+    }
+
     services   = "10.25.0.0/16"
   }
 

--- a/docs/examples/libvirt/cluster.tf
+++ b/docs/examples/libvirt/cluster.tf
@@ -29,7 +29,9 @@ data "template_file" "cloud_init_user_data" {
 
 resource "kubeadm" "main" {
   network {
-    dns_domain = "mycluster.com"
+    dns {
+      domain = "mycluster.com"
+    }
     services   = "10.25.0.0/16"
   }
 

--- a/docs/examples/lxd/cluster.tf
+++ b/docs/examples/lxd/cluster.tf
@@ -15,7 +15,9 @@ resource "kubeadm" "main" {
   config_path = "${var.kubeconfig}"
 
   network {
-    dns_domain = "mycluster.com"
+    dns {
+      domain = "mycluster.com"
+    }
     services   = "10.25.0.0/16"
   }
 

--- a/internal/ssh/base.go
+++ b/internal/ssh/base.go
@@ -227,8 +227,9 @@ func (f CheckerFunc) Check(ctx context.Context) (bool, error) {
 	return f(ctx)
 }
 
-// DoWithCleanup runs some action and, despite the result, runs the cleanup function
-// It returns the actions result.
+// DoWithCleanup runs some action(s) and
+// 1) despite the result, runs the cleanup function
+// 2) returns the actions result
 func DoWithCleanup(actions Action, cleanup Action) Action {
 	return ActionFunc(func(ctx context.Context) Action {
 		res := ActionList{actions}.Apply(ctx)
@@ -237,7 +238,9 @@ func DoWithCleanup(actions Action, cleanup Action) Action {
 	})
 }
 
-// DoWithException runs some action and, if some error happens, runs the exception
+// DoWithException runs some action and
+// 1) if some error happens, runs the exception handler
+// 2) returns the error
 func DoWithException(actions Action, exc Action) Action {
 	return ActionFunc(func(ctx context.Context) Action {
 		res := ActionList{actions}.Apply(ctx)
@@ -248,7 +251,9 @@ func DoWithException(actions Action, exc Action) Action {
 	})
 }
 
-// DoWithSuccess runs some action and, if no error happend, runs a success action
+// DoWithSuccess runs some action and
+// 1) if no error happens, runs a success action
+// 2) returns the action(s) result
 func DoWithSuccess(actions Action, suc Action) Action {
 	return ActionFunc(func(ctx context.Context) Action {
 		res := ActionList{actions}.Apply(ctx)

--- a/internal/ssh/cache.go
+++ b/internal/ssh/cache.go
@@ -106,6 +106,22 @@ func DoSetInCache(key string, value interface{}) Action {
 	})
 }
 
+// DoFlushCache flushes the cache
+func DoFlushCache() Action {
+	return ActionFunc(func(ctx context.Context) Action {
+		if isCacheDisabled() {
+			return nil
+		}
+		sctx := getSSHContext(ctx)
+		sctx.cache = cache{}
+		return nil
+	})
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Checks
+/////////////////////////////////////////////////////////////////////////////
+
 // CheckInCache returns true if the key is in the cache
 func CheckInCache(key string) CheckerFunc {
 	return CheckerFunc(func(ctx context.Context) (bool, error) {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -69,6 +69,9 @@ const (
 
 	// kubectl executable in the machines (we assume it is in some standard path)
 	DefKubectlPath = "kubectl"
+
+	// resolv.conf for pods when upstream servers are provided
+	DefResolvUpstreamConf = "/etc/resolv.conf-kubeadm"
 )
 
 var (

--- a/pkg/common/provisioner.go
+++ b/pkg/common/provisioner.go
@@ -84,6 +84,11 @@ var ProvisionerConfigElements = map[string]*schema.Schema{
 		// Computed: true,
 		Optional: true,
 	},
+	"dns_upstream": {
+		Type: schema.TypeString,
+		// Computed: true,
+		Optional: true,
+	},
 	"flannel_backend": {
 		Type:        schema.TypeString,
 		Optional:    true,

--- a/pkg/provider/kubeadm_init_test.go
+++ b/pkg/provider/kubeadm_init_test.go
@@ -29,7 +29,7 @@ func TestKubeadmInitConfigSerialization(t *testing.T) {
 	token := "82eb2m.999999idy9l74yha"
 
 	d.Set("api.0.internal", "10.10.0.1")
-	d.Set("network.0.dns_domain", "my-local.cluster")
+	d.Set("network.0.dns.0.domain", "my-local.cluster")
 
 	initConfig, err := dataSourceToInitConfig(&d, token)
 	if err != nil {

--- a/pkg/provider/kubeadm_join.go
+++ b/pkg/provider/kubeadm_join.go
@@ -56,6 +56,17 @@ func dataSourceToJoinConfig(d *schema.ResourceData, token string) (*kubeadmapi.J
 		}
 	}
 
+	if _, ok := d.GetOk("network.0"); ok {
+		if _, ok := d.GetOk("network.0.dns.0"); ok {
+			if dnsUpstreamOpt, ok := d.GetOk("network.0.dns.0.upstream"); ok {
+				dnsUp := dnsUpstreamOpt.([]interface{})
+				if len(dnsUp) > 0 {
+					joinConfig.NodeRegistration.KubeletExtraArgs["resolv-conf"] = common.DefResolvUpstreamConf
+				}
+			}
+		}
+	}
+
 	// check if we have some cloud-provider
 	if cloudProvRaw, ok := d.GetOk("cloud.0.provider"); ok && len(cloudProvRaw.(string)) > 0 {
 		joinConfig.NodeRegistration.KubeletExtraArgs["cloud-provider"] = "external"

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -188,6 +188,17 @@ func createConfigForProvisioner(d *schema.ResourceData) error {
 		provConfig["flannel_image_version"] = common.DefFlannelImageVersion
 	}
 
+	if v, ok := d.GetOk("network.0.dns.0.upstream"); ok {
+		dnsUp := v.([]interface{})
+		if len(dnsUp) > 0 {
+			res := ""
+			for _, s := range dnsUp {
+				res = res + " " + s.(string)
+			}
+			provConfig["dns_upstream"] = res
+		}
+	}
+
 	if version, ok := d.GetOk("version"); ok {
 		provConfig["kube_version"] = version.(string)
 	} else {

--- a/pkg/provider/schema.go
+++ b/pkg/provider/schema.go
@@ -195,12 +195,28 @@ func dataSourceKubeadm() *schema.Resource {
 							Description:  "subnet used by pods",
 							ValidateFunc: validation.CIDRNetwork(0, 32),
 						},
-						"dns_domain": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      common.DefDNSDomain,
-							Description:  "DNS domain used by k8s services. Defaults to cluster.local.",
-							ValidateFunc: common.ValidateDNSName,
+						"dns": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"domain": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      common.DefDNSDomain,
+										Description:  "DNS domain used by k8s services. Defaults to cluster.local.",
+										ValidateFunc: common.ValidateDNSName,
+									},
+									"upstream": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: "upstream DNS servers",
+										Elem:        &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/provisioner/action_common.go
+++ b/pkg/provisioner/action_common.go
@@ -115,6 +115,7 @@ func doMaybeResetWorker(d *schema.ResourceData, kubeadmConfigFilename string) ss
 			ssh.DoMessageWarn("previous kubeadm config file found: resetting node"),
 			doExecKubeadmWithConfig(d, "reset", "", "--force"),
 			ssh.DoDeleteFile(kubeadmConfigFilename),
+			ssh.DoFlushCache(),
 		})
 }
 

--- a/pkg/provisioner/action_init.go
+++ b/pkg/provisioner/action_init.go
@@ -92,5 +92,6 @@ func doMaybeResetMaster(d *schema.ResourceData, kubeadmConfigFilename string) ss
 			ssh.DoMessageWarn("previous kubeadm config file found: resetting node"),
 			doExecKubeadmWithConfig(d, "reset", "", "--force"),
 			ssh.DoDeleteFile(kubeadmConfigFilename),
+			ssh.DoFlushCache(),
 		})
 }

--- a/pkg/provisioner/action_init_helm.go
+++ b/pkg/provisioner/action_init_helm.go
@@ -63,8 +63,12 @@ func doLoadHelm(d *schema.ResourceData) ssh.Action {
 	allManifests := strings.Join(manifests, "\n---\n")
 	ssh.Debug("Helm manifests: %s", allManifests)
 
+	kubeconfig := getKubeconfigFromResourceData(d)
+
 	return ssh.ActionList{
 		ssh.DoMessageInfo("Loading Helm..."),
 		doRemoteKubectlApply(d, []ssh.Manifest{{Inline: allManifests}}),
+		ssh.DoMessageInfo("Now you should initialize the client with 'helm --kubeconfig=%s init'", kubeconfig),
+		ssh.DoMessageInfo("Then you can install charts with something like 'helm install --kubeconfig=%s --generate-name ...'", kubeconfig),
 	}
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -104,6 +104,7 @@ func applyFn(ctx context.Context) error {
 		ssh.DoMessageInfo("Checking we have the required binaries..."),
 		doCheckCommonBinaries(d),
 		doPrepareCRI(),
+		doUploadResolvConf(d),
 		ssh.DoEnableService("kubelet.service"),
 		ssh.DoUploadBytesToFile([]byte(assets.KubeletSysconfigCode), getSysconfigPathFromResourceData(d)),
 		ssh.DoUploadBytesToFile([]byte(assets.KubeletServiceCode), getServicePathFromResourceData(d)),


### PR DESCRIPTION
* Options for specifying a the upstream DNS servers for the kubernetes cluster (necessary when the node has a caching DNS or some other weird DNS configuration that can make crazy to the CoreDNS server).
* Some improvements in the cache.
* Improved logging on failures.